### PR TITLE
Activate AMF intra refresh (GDR) - fixing xbox moonlight artefacts 

### DIFF
--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -1899,6 +1899,29 @@ if (client_config.enableIntraRefresh == 1) {
       return false;
     };
 
+// BEGIN INSERT2
+// Check if GDR is requested by client
+if (encoder && current_config.enableIntraRefresh == 1) {
+    AMF_RESULT res;
+
+    if (force_idr) {
+        res = surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_NONE);
+        if (res != AMF_OK) {
+            BOOST_LOG(warning) << "AMF GDR: Failed to set FORCE_PICTURE_TYPE (IDR interception)";
+        }
+        res = surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_INSERT_HEADER, true);
+        if (res != AMF_OK) {
+            BOOST_LOG(warning) << "AMF GDR: Failed to set INSERT_HEADER";
+        }
+    } else {
+        res = surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_NONE);
+        if (res != AMF_OK) {
+            BOOST_LOG(warning) << "AMF GDR: Failed to set FORCE_PICTURE_TYPE (Normal operation)";
+        }
+    }
+}
+// END INSERT2
+    
     auto set_forced_idr_properties = [&]() {
       auto check = [&](AMF_RESULT property_result, const char *label) {
         if (property_result == AMF_OK) return true;

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -988,50 +988,45 @@ namespace amf {
       if (config.pa_activity_type && !set_verified_int64(AMF_PA_ACTIVITY_TYPE, *config.pa_activity_type, "PA activity type")) return false;
     }
 
-// BEGIN INSERT1 (Xbox-Safe driver-autonomous HEVC GDR configuration)
+// BEGIN INSERT1 (HEVC GDR configuration)
+// Check if the connected client explicitly requested Intra-Refresh (GDR)
+if (client_config.enableIntraRefresh == 1) {
   AMF_RESULT probe_res = encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, 120);
 
   if (probe_res == AMF_OK) {
-  BOOST_LOG(info) << "AMF: Initializing driver-autonomous HEVC Intra-Refresh (GDR)...";
+    BOOST_LOG(info) << "AMF: Client requested GDR. Initializing driver-autonomous HEVC Intra-Refresh...";
 
-  // NOTE: AMF_VIDEO_ENCODER_IDR_PERIOD is intentionally omitted. 
-  // Forcing a manual IDR period during GDR mode causes the AMD driver to reject 
-  // the property (applied=0), which triggers strict hardware decoder crashes on Xbox.
-  // We leave IDR management entirely to the driver's internal state machine.
+    int64_t gop_size = 120; 
+    encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, gop_size);
 
-  int64_t gop_size = 120; 
-  encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, gop_size);
+    int64_t actual_width = encode_width;   
+    int64_t actual_height = encode_height; 
+    
+    if (actual_width <= 0)  actual_width = 3840;
+    if (actual_height <= 0) actual_height = 2160;
 
-  // Mathematically correct CTB calculation using local Sunshine variables
-  int64_t actual_width = encode_width;   
-  int64_t actual_height = encode_height; 
+    int64_t ctu_size = 64;
+    int64_t ctu_width = (actual_width + (ctu_size - 1)) / ctu_size;
+    int64_t ctu_height = (actual_height + (ctu_size - 1)) / ctu_size;
 
-  // FALLBACK: If the encoder reports 0 dimensions during the very first initialization pass,
-  // we enforce 4K defaults to prevent the formula from collapsing into an invalid "value = 1" loop.
-  if (actual_width <= 0)  actual_width = 3840;
-  if (actual_height <= 0) actual_height = 2160;
+    int64_t ctu_rows_per_frame = (ctu_height + gop_size - 1) / gop_size;
+    if (ctu_rows_per_frame < 1) ctu_rows_per_frame = 1;
 
-  int64_t ctu_size = 64;
-  int64_t ctu_width = (actual_width + (ctu_size - 1)) / ctu_size;
-  int64_t ctu_height = (actual_height + (ctu_size - 1)) / ctu_size;
+    int64_t total_ctbs_per_frame = ctu_rows_per_frame * ctu_width;
 
-  int64_t ctu_rows_per_frame = (ctu_height + gop_size - 1) / gop_size;
-  if (ctu_rows_per_frame < 1) ctu_rows_per_frame = 1;
+    if (!set_verified_int64(AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT, total_ctbs_per_frame, "HEVC GDR CTBs per Slot")) {
+      return false;
+    }
 
-  // Calculate the total number of blocks per frame required for a proper horizontal refresh
-  int64_t total_ctbs_per_frame = ctu_rows_per_frame * ctu_width;
-
-  if (!set_verified_int64(AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT, total_ctbs_per_frame, "HEVC GDR CTBs per Slot")) {
-    return false;
+    BOOST_LOG(info) << "AMF: Native GDR mode successfully activated! CTBs per frame: " << total_ctbs_per_frame;
+  } else {
+    // Silent fallback during H.264 / AV1 capability probing at Sunshine startup
+    BOOST_LOG(debug) << "AMF: Skipping GDR setup (H.264 or AV1 validation active)";
   }
-
-  BOOST_LOG(info) << "AMF: Native GDR mode successfully activated! CTBs per frame: " << total_ctbs_per_frame;
 } else {
-  // Silent fallback during H.264 / AV1 capability probing at Sunshine startup
-  BOOST_LOG(debug) << "AMF: Skipping GDR setup (H.264 or AV1 validation active)";
+  BOOST_LOG(info) << "AMF: Intra-Refresh disabled (not requested by client configuration)";
 }
 // END INSERT1
-    
     
     // NOTE: LOWLATENCY_MODE is intentionally NOT forced here.
     //

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -987,24 +987,51 @@ namespace amf {
             "PA initial scene-change QP")) return false;
       if (config.pa_activity_type && !set_verified_int64(AMF_PA_ACTIVITY_TYPE, *config.pa_activity_type, "PA activity type")) return false;
     }
-    
-//BEGIN INSERT1
-// Activate AMF GDR intra refresh for 4k HDR 60fps
-    BOOST_LOG(info) << "AMF: Force encoder into HEVC Intra-Refresh (GDR) Mode (gop_size = 120 und ctu_size = 64)";
 
-    encoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, 0);
+// BEGIN INSERT1 (Xbox-Safe driver-autonomous HEVC GDR configuration)
+  AMF_RESULT probe_res = encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, 120);
 
-    int64_t gop_size = 120; 
-    encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, gop_size);
+  if (probe_res == AMF_OK) {
+  BOOST_LOG(info) << "AMF: Initializing driver-autonomous HEVC Intra-Refresh (GDR)...";
 
-    int64_t ctu_size = 64;
-    int64_t ctu_height = (encode_height + (ctu_size - 1)) / ctu_size;
+  // NOTE: AMF_VIDEO_ENCODER_IDR_PERIOD is intentionally omitted. 
+  // Forcing a manual IDR period during GDR mode causes the AMD driver to reject 
+  // the property (applied=0), which triggers strict hardware decoder crashes on Xbox.
+  // We leave IDR management entirely to the driver's internal state machine.
 
-    int64_t ctu_rows_per_frame = (ctu_height + gop_size - 1) / gop_size;
-    if (ctu_rows_per_frame < 1) ctu_rows_per_frame = 1; // Mindestens eine Zeile pro Frame
+  int64_t gop_size = 120; 
+  encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, gop_size);
 
-encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT, ctu_rows_per_frame);
+  // Mathematically correct CTB calculation using local Sunshine variables
+  int64_t actual_width = encode_width;   
+  int64_t actual_height = encode_height; 
+
+  // FALLBACK: If the encoder reports 0 dimensions during the very first initialization pass,
+  // we enforce 4K defaults to prevent the formula from collapsing into an invalid "value = 1" loop.
+  if (actual_width <= 0)  actual_width = 3840;
+  if (actual_height <= 0) actual_height = 2160;
+
+  int64_t ctu_size = 64;
+  int64_t ctu_width = (actual_width + (ctu_size - 1)) / ctu_size;
+  int64_t ctu_height = (actual_height + (ctu_size - 1)) / ctu_size;
+
+  int64_t ctu_rows_per_frame = (ctu_height + gop_size - 1) / gop_size;
+  if (ctu_rows_per_frame < 1) ctu_rows_per_frame = 1;
+
+  // Calculate the total number of blocks per frame required for a proper horizontal refresh
+  int64_t total_ctbs_per_frame = ctu_rows_per_frame * ctu_width;
+
+  if (!set_verified_int64(AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT, total_ctbs_per_frame, "HEVC GDR CTBs per Slot")) {
+    return false;
+  }
+
+  BOOST_LOG(info) << "AMF: Native GDR mode successfully activated! CTBs per frame: " << total_ctbs_per_frame;
+} else {
+  // Silent fallback during H.264 / AV1 capability probing at Sunshine startup
+  BOOST_LOG(debug) << "AMF: Skipping GDR setup (H.264 or AV1 validation active)";
+}
 // END INSERT1
+    
     
     // NOTE: LOWLATENCY_MODE is intentionally NOT forced here.
     //
@@ -1856,15 +1883,6 @@ encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT, ctu
         }
       }
     }
-
-//BEGIN INSERT2
-    if (force_idr) {
-      surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_NONE);
-      surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_INSERT_HEADER, true);
-    } else {
-      surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_NONE);
-    }
-//END INSERT2
     
     auto disable_rfi_after_property_failure = [&](const char *property_label, AMF_RESULT property_result) {
       BOOST_LOG(warning) << "AMF: failed to apply " << property_label << " (error=" << property_result

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -988,42 +988,31 @@ namespace amf {
       if (config.pa_activity_type && !set_verified_int64(AMF_PA_ACTIVITY_TYPE, *config.pa_activity_type, "PA activity type")) return false;
     }
 
-// BEGIN INSERT1 (HEVC GDR configuration)
-// Check if the connected client explicitly requested Intra-Refresh (GDR)
+// BEGIN INSERT1 (HEVC Gradual Decoder Refresh configuration)
 if (client_config.enableIntraRefresh == 1) {
-  AMF_RESULT probe_res = encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, 120);
+  constexpr int64_t GOP_SIZE = 120;
+  constexpr int64_t CTU_SIZE = 64;
+  if (encoder -> SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, GOP_SIZE) == AMF_OK) {
+    const int64_t width = (encode_width > 0) ? encode_width : 3840;
+    const int64_t height = (encode_height > 0) ? encode_height : 2160;
+    const int64_t ctu_width = (width + CTU_SIZE - 1) / CTU_SIZE;
+    const int64_t ctu_height = (height + CTU_SIZE - 1) / CTU_SIZE;
 
-  if (probe_res == AMF_OK) {
-    BOOST_LOG(info) << "AMF: Client requested GDR. Initializing driver-autonomous HEVC Intra-Refresh...";
+    const int64_t ctbs_per_slot =
+      std::max < int64_t > (1, (ctu_height + GOP_SIZE - 1) / GOP_SIZE) * ctu_width;
 
-    int64_t gop_size = 120; 
-    encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, gop_size);
-
-    int64_t actual_width = encode_width;   
-    int64_t actual_height = encode_height; 
-    
-    if (actual_width <= 0)  actual_width = 3840;
-    if (actual_height <= 0) actual_height = 2160;
-
-    int64_t ctu_size = 64;
-    int64_t ctu_width = (actual_width + (ctu_size - 1)) / ctu_size;
-    int64_t ctu_height = (actual_height + (ctu_size - 1)) / ctu_size;
-
-    int64_t ctu_rows_per_frame = (ctu_height + gop_size - 1) / gop_size;
-    if (ctu_rows_per_frame < 1) ctu_rows_per_frame = 1;
-
-    int64_t total_ctbs_per_frame = ctu_rows_per_frame * ctu_width;
-
-    if (!set_verified_int64(AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT, total_ctbs_per_frame, "HEVC GDR CTBs per Slot")) {
+    if (!set_verified_int64(
+        AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT,
+        ctbs_per_slot,
+        "HEVC GDR CTBs Per Slot")) {
       return false;
     }
-
-    BOOST_LOG(info) << "AMF: Native GDR mode successfully activated!";
-  } else {
-    BOOST_LOG(debug) << "AMF: Skipping GDR setup (H.264 or AV1 validation active)";
-  }
+    BOOST_LOG(info) <<
+      "AMF: HEVC Intra-Refresh (GDR) enabled.";
+  } 
 } else {
-  BOOST_LOG(info) << "AMF: Intra-Refresh disabled (not requested by client configuration)";
+  BOOST_LOG(info) <<
+    "AMF: Intra-Refresh disabled (not requested by client)";
 }
 // END INSERT1
     
@@ -1899,26 +1888,18 @@ if (client_config.enableIntraRefresh == 1) {
       return false;
     };
 
-// BEGIN INSERT2
-// Check if GDR is requested by client
-if (encoder && current_config.enableIntraRefresh == 1) {
-    AMF_RESULT res;
-
-    if (force_idr) {
-        res = surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_NONE);
-        if (res != AMF_OK) {
-            BOOST_LOG(warning) << "AMF GDR: Failed to set FORCE_PICTURE_TYPE (IDR interception)";
-        }
-        res = surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_INSERT_HEADER, true);
-        if (res != AMF_OK) {
-            BOOST_LOG(warning) << "AMF GDR: Failed to set INSERT_HEADER";
-        }
-    } else {
-        res = surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_NONE);
-        if (res != AMF_OK) {
-            BOOST_LOG(warning) << "AMF GDR: Failed to set FORCE_PICTURE_TYPE (Normal operation)";
-        }
-    }
+// BEGIN INSERT2 (HEVC GDR IDR interception)
+if (encoder && current_config.enableIntraRefresh == 1 && force_idr) {
+  if (surface -> SetProperty(
+      AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE,
+      AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_NONE) != AMF_OK) {
+    BOOST_LOG(warning) << "AMF GDR: Failed to suppress IDR request";
+  }
+  if (surface -> SetProperty(
+      AMF_VIDEO_ENCODER_HEVC_INSERT_HEADER,
+      true) != AMF_OK) {
+    BOOST_LOG(warning) << "AMF GDR: Failed to insert VPS/SPS/PPS";
+  }
 }
 // END INSERT2
     

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -1895,7 +1895,7 @@ if (client_config.enableIntraRefresh == 1) {
 if (encoder && current_config.enableIntraRefresh == 1 && force_idr) {
   if (surface -> SetProperty(
       AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE,
-      AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_NONE) != AMF_OK) {
+      AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_I) != AMF_OK) {
     BOOST_LOG(warning) << "AMF GDR: Failed to suppress IDR request";
   }
   if (surface -> SetProperty(

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -998,9 +998,7 @@ namespace amf {
     encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, gop_size);
 
     int64_t ctu_size = 64;
-    int64_t ctu_width = (encode_width + (ctu_size - 1)) / ctu_size;
     int64_t ctu_height = (encode_height + (ctu_size - 1)) / ctu_size;
-    int64_t total_ctus = ctu_width * ctu_height;
 
     int64_t ctu_rows_per_frame = (ctu_height + gop_size - 1) / gop_size;
     if (ctu_rows_per_frame < 1) ctu_rows_per_frame = 1; // Mindestens eine Zeile pro Frame

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -1018,9 +1018,8 @@ if (client_config.enableIntraRefresh == 1) {
       return false;
     }
 
-    BOOST_LOG(info) << "AMF: Native GDR mode successfully activated! CTBs per frame: " << total_ctbs_per_frame;
+    BOOST_LOG(info) << "AMF: Native GDR mode successfully activated!";
   } else {
-    // Silent fallback during H.264 / AV1 capability probing at Sunshine startup
     BOOST_LOG(debug) << "AMF: Skipping GDR setup (H.264 or AV1 validation active)";
   }
 } else {

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -987,7 +987,27 @@ namespace amf {
             "PA initial scene-change QP")) return false;
       if (config.pa_activity_type && !set_verified_int64(AMF_PA_ACTIVITY_TYPE, *config.pa_activity_type, "PA activity type")) return false;
     }
+    
+//BEGIN INSERT1
+// Activate AMF GDR intra refresh for 4k HDR 60fps
+    BOOST_LOG(info) << "AMF: Force encoder into HEVC Intra-Refresh (GDR) Mode (gop_size = 120 und ctu_size = 64)";
 
+    encoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, 0);
+
+    int64_t gop_size = 120; 
+    encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, gop_size);
+
+    int64_t ctu_size = 64;
+    int64_t ctu_width = (encode_width + (ctu_size - 1)) / ctu_size;
+    int64_t ctu_height = (encode_height + (ctu_size - 1)) / ctu_size;
+    int64_t total_ctus = ctu_width * ctu_height;
+
+    int64_t ctu_rows_per_frame = (ctu_height + gop_size - 1) / gop_size;
+    if (ctu_rows_per_frame < 1) ctu_rows_per_frame = 1; // Mindestens eine Zeile pro Frame
+
+encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT, ctu_rows_per_frame);
+// END INSERT1
+    
     // NOTE: LOWLATENCY_MODE is intentionally NOT forced here.
     //
     // Previously this block hard-coded AMF_VIDEO_ENCODER_(HEVC_)LOWLATENCY_MODE = true
@@ -1839,6 +1859,15 @@ namespace amf {
       }
     }
 
+//BEGIN INSERT2
+    if (force_idr) {
+      surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_NONE);
+      surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_INSERT_HEADER, true);
+    } else {
+      surface->SetProperty(AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_NONE);
+    }
+//END INSERT2
+    
     auto disable_rfi_after_property_failure = [&](const char *property_label, AMF_RESULT property_result) {
       BOOST_LOG(warning) << "AMF: failed to apply " << property_label << " (error=" << property_result
                          << "); disabling RFI and falling back to IDR recovery";

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -990,16 +990,21 @@ namespace amf {
 
 // BEGIN INSERT1 (HEVC Gradual Decoder Refresh configuration)
 if (client_config.enableIntraRefresh == 1) {
-  constexpr int64_t GOP_SIZE = 120;
+  constexpr int64_t GOP_SIZE = 120; 
   constexpr int64_t CTU_SIZE = 64;
-  if (encoder -> SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, GOP_SIZE) == AMF_OK) {
+  
+  encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, 0);
+  
+  if (encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, GOP_SIZE) == AMF_OK) {
     const int64_t width = (encode_width > 0) ? encode_width : 3840;
     const int64_t height = (encode_height > 0) ? encode_height : 2160;
-    const int64_t ctu_width = (width + CTU_SIZE - 1) / CTU_SIZE;
-    const int64_t ctu_height = (height + CTU_SIZE - 1) / CTU_SIZE;
+    
+    const int64_t ctu_width = (width + CTU_SIZE - 1) / CTU_SIZE;  
+    const int64_t ctu_height = (height + CTU_SIZE - 1) / CTU_SIZE; 
 
-    const int64_t ctbs_per_slot =
-      std::max < int64_t > (1, (ctu_height + GOP_SIZE - 1) / GOP_SIZE) * ctu_width;
+    constexpr int64_t TARGET_DURATION = GOP_SIZE; 
+    const int64_t ctbs_per_slot = 
+      std::max<int64_t>(1, (ctu_width * ctu_height) / TARGET_DURATION); 
 
     if (!set_verified_int64(
         AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT,
@@ -1007,12 +1012,10 @@ if (client_config.enableIntraRefresh == 1) {
         "HEVC GDR CTBs Per Slot")) {
       return false;
     }
-    BOOST_LOG(info) <<
-      "AMF: HEVC Intra-Refresh (GDR) enabled.";
+    BOOST_LOG(info) << "AMF: Fixed HEVC GDR active. " << ctbs_per_slot << " CTBs/slot configured.";
   } 
 } else {
-  BOOST_LOG(info) <<
-    "AMF: Intra-Refresh disabled (not requested by client)";
+  BOOST_LOG(info) << "AMF: Intra-Refresh disabled (not requested by client)";
 }
 // END INSERT1
     


### PR DESCRIPTION
In the latest versions of Vibeshine/Vibepollo AMD Intra Refresh (GDR) for HEVC does not work, even though the log reads otherwise. It looks like die AMF encoder is not configured correctly for that purpose and the infamous artefacts on Xbox in still/slow moving scenes still occur.

This code now works perfectly for me, 4k HDR 60fps, real AMF GDR intra refresh is at work and no additional stutters have been introduced. The dreaded Xbox artefacts are gone. 

Keep in mind that this code has intra refresh hard coded and fixed values for GOP and CTU size.