### PR TITLE
feat(display): size virtual displays from the client's image area

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4269,13 +4269,21 @@ Measure the **image area**, not the device. On a letterboxed panel the two diffe
 8.0-inch inner panel of a Galaxy Z Fold8 Ultra occupies only about 7.01 inches of it. The height is
 derived from the width and the requested mode, so only the width is configured.
 
-Known-good widths, as a starting point — this is an ordinary list, so add your own device by measuring
-its image area:
+Devices that have already been worked out are offered as suggestions in the web UI, on the global
+setting and on the per-client and per-app overrides alike, so the common cases do not have to be
+measured twice:
 
 | Client | Mode | Image area (mm) | Width to configure | Density |
 | --- | --- | --- | --- | --- |
 | Alienware m16 R2 | 2560x1600 | 344.68 x 215.42 | `345` | 188.65 PPI |
 | Galaxy Z Fold8 Ultra (inner panel, landscape) | 2504x2256 | 150.97 x 136.01 | `151` | 421.3 PPI |
+
+That table is an ordinary list of examples rather than a supported-device list, and the suggestions
+never restrict the field: measure your own device's image area and type the width in. To offer a
+device to everyone, add a row to `src_assets/common/assets/web/configs/clientImageWidthPresets.ts`.
+The listed width is the panel's full active width, which a stream wider in aspect than the panel
+fills even while letterboxed; a stream narrower than the panel is pillarboxed and needs a smaller
+number.
 
 `dd_virtual_display_scale` still wins when set to an explicit percentage, and `0` (preserve Windows'
 choice) still leaves the Windows DPI setting alone. The measured width only replaces the automatic

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4254,6 +4254,33 @@ Controls high-motion quality boost for the experimental native AMD encoder. Use 
 
 Sets how long a paused virtual display may remain ready before the display helper releases it. Set `0` to disable the timeout.
 
+### dd_virtual_display_image_width_mm
+
+Sets the width, in millimetres, of the image area the client actually displays. Set `0` to disable.
+
+The stream protocol carries pixels, not physical dimensions, so the host cannot tell a 2504-pixel-wide
+phone panel from a 2504-pixel-wide desktop monitor. Left to itself it guesses a scale from the
+resolution, and buttons, text, and the cursor end up a different physical size on the client than they
+are on the host's own monitor. Measuring the image area once removes the guess: the virtual display
+advertises those dimensions in its EDID, Windows derives DPI from them the same way it does for a real
+monitor, and interface elements come out at their true physical size.
+
+Measure the **image area**, not the device. On a letterboxed panel the two differ: a 16:10 stream on the
+8.0-inch inner panel of a Galaxy Z Fold8 Ultra occupies only about 7.01 inches of it. The height is
+derived from the width and the requested mode, so only the width is configured.
+
+Known-good widths, as a starting point — this is an ordinary list, so add your own device by measuring
+its image area:
+
+| Client | Mode | Image area (mm) | Width to configure | Density |
+| --- | --- | --- | --- | --- |
+| Alienware m16 R2 | 2560x1600 | 344.68 x 215.42 | `345` | 188.65 PPI |
+| Galaxy Z Fold8 Ultra (inner panel, landscape) | 2504x2256 | 150.97 x 136.01 | `151` | 421.3 PPI |
+
+`dd_virtual_display_scale` still wins when set to an explicit percentage, and `0` (preserve Windows'
+choice) still leaves the Windows DPI setting alone. The measured width only replaces the automatic
+recommendation.
+
 ### dd_virtual_display_scale
 
 Sets the virtual-display scale override. Leave it unset or at the automatic setting to use the recommended scale for the requested display mode.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -930,6 +930,7 @@ namespace config {
       true,  // use_sunshine_virtual_display_driver
       false,  // activate_virtual_display
       -1,  // virtual_display_scale_percent
+      0,  // virtual_display_image_width_mm
       0,  // virtual_display_permanent_count
       false,  // virtual_display_permanent_count_configured
       {},  // snapshot_exclude_devices
@@ -1820,6 +1821,18 @@ namespace config {
                            << "%; use -1 (recommended), 0, 100, 125, 150, 175, 200, 225, 250, 300, 350, 400, 450, or 500.";
       }
     }
+    {
+      int value = video.dd.virtual_display_image_width_mm;
+      int_f(vars, "dd_virtual_display_image_width_mm", value);
+      // Mirrors VDISPLAY::kMinImageWidthMillimeters/kMaxImageWidthMillimeters, which live in a
+      // Windows-only header this platform-neutral parser cannot include.
+      if (value == 0 || (value >= 10 && value <= 2000)) {
+        video.dd.virtual_display_image_width_mm = value;
+      } else {
+        BOOST_LOG(warning) << "Ignoring out-of-range virtual display image width " << value
+                           << " mm; use 0 to disable, or 10-2000.";
+      }
+    }
     bool_f(vars, "vulkan_hdr_layer", video.dd.vulkan_hdr_layer);
     {
       auto it = vars.find("dd_virtual_display_permanent_count");
@@ -2483,6 +2496,7 @@ namespace config {
         "dd_use_sunshine_virtual_display_driver",
         "dd_activate_virtual_display",
         "dd_virtual_display_scale",
+        "dd_virtual_display_image_width_mm",
         "dd_virtual_display_permanent_count",
         "dd_mode_remapping",
         "dd_wa_dummy_plug_hdr10",
@@ -2984,6 +2998,7 @@ namespace config {
       const auto prev_dd_use_sunshine_virtual_display_driver = video.dd.use_sunshine_virtual_display_driver;
       const auto prev_dd_activate_virtual_display = video.dd.activate_virtual_display;
       const auto prev_dd_virtual_display_scale_percent = video.dd.virtual_display_scale_percent;
+      const auto prev_dd_virtual_display_image_width_mm = video.dd.virtual_display_image_width_mm;
       const auto prev_dd_virtual_display_permanent_count = video.dd.virtual_display_permanent_count;
       const auto prev_dd_virtual_display_permanent_count_configured = video.dd.virtual_display_permanent_count_configured;
       const auto prev_dd_snapshot_exclude_devices = video.dd.snapshot_exclude_devices;
@@ -3058,6 +3073,7 @@ namespace config {
                                      (prev_dd_use_sunshine_virtual_display_driver != video.dd.use_sunshine_virtual_display_driver) ||
                                      (prev_dd_activate_virtual_display != video.dd.activate_virtual_display) ||
                                      (prev_dd_virtual_display_scale_percent != video.dd.virtual_display_scale_percent) ||
+                                     (prev_dd_virtual_display_image_width_mm != video.dd.virtual_display_image_width_mm) ||
                                      (prev_dd_virtual_display_permanent_count != video.dd.virtual_display_permanent_count) ||
                                      (prev_dd_virtual_display_permanent_count_configured != video.dd.virtual_display_permanent_count_configured) ||
                                      (prev_dd_snapshot_exclude_devices != video.dd.snapshot_exclude_devices) ||

--- a/src/config.h
+++ b/src/config.h
@@ -221,6 +221,7 @@ namespace config {
       bool use_sunshine_virtual_display_driver;  ///< Use the Vibeshine Display Driver instead of rollback drivers such as SudoVDA.
       bool activate_virtual_display;  ///< Auto-activate Sunshine virtual display when selected as the target output.
       int virtual_display_scale_percent;  ///< Windows scale for virtual displays (-1 is resolution-based; 0 preserves Windows' choice).
+      int virtual_display_image_width_mm;  ///< Width of the client's visible image area in millimetres (0 disables). Drives the synthetic EDID so Windows derives DPI from a real physical size.
       int virtual_display_permanent_count;  ///< Number of always-present Sunshine virtual displays to request when explicitly configured.
       bool virtual_display_permanent_count_configured;  ///< False preserves installs that predate this setting.
       std::vector<std::string> snapshot_exclude_devices;  ///< Device IDs to skip when saving display snapshots.

--- a/src/platform/windows/virtual_display.h
+++ b/src/platform/windows/virtual_display.h
@@ -67,12 +67,40 @@ namespace VDISPLAY {
     std::uint32_t scale_percent
   );
 
-  // Resolve the configured virtual-display scale. -1 selects a resolution-based
-  // recommendation, 0 preserves Windows' existing choice, and positive values are exact.
+  // Physical size of the image area a virtual display advertises through its synthetic EDID.
+  struct virtual_display_physical_size_t {
+    std::uint32_t width_mm = 0;
+    std::uint32_t height_mm = 0;
+  };
+
+  // Lowest and highest client image widths we accept, in millimetres. The range spans a
+  // phone's inner panel up to a projected image; anything outside it is a typo, not a display.
+  inline constexpr int kMinImageWidthMillimeters = 10;
+  inline constexpr int kMaxImageWidthMillimeters = 2000;
+
+  // The DPI a 100% Windows scale factor is defined against.
+  inline constexpr double kWindowsReferenceDpi = 96.0;
+
+  // Resolve the image area a virtual display should advertise, from the measured width of the
+  // client's visible image and the mode being requested. Returns nullopt when no width is
+  // configured, leaving callers on the scale-derived EDID. Height follows the mode's pixel
+  // aspect: the streamed image fills the client's image area, so its pixels are square even
+  // when the client's panel is not the same shape as the image.
+  std::optional<virtual_display_physical_size_t> virtual_display_physical_size_mm(
+    int configured_image_width_mm,
+    std::uint32_t width,
+    std::uint32_t height
+  );
+
+  // Resolve the configured virtual-display scale. -1 selects a recommendation, 0 preserves
+  // Windows' existing choice, and positive values are exact. A measured client image width
+  // refines the recommendation: it describes the client's pixel density exactly, where the
+  // resolution-only heuristic can only guess at it.
   std::uint32_t effective_virtual_display_scale_percent(
     int configured_scale_percent,
     std::uint32_t width,
-    std::uint32_t height
+    std::uint32_t height,
+    int configured_image_width_mm = 0
   );
 
   // Read the MHC2 peak-luminance value from a Windows HDR calibration profile selection.

--- a/src/platform/windows/virtual_display_identity.cpp
+++ b/src/platform/windows/virtual_display_identity.cpp
@@ -12,6 +12,24 @@ namespace {
     100, 125, 150, 175, 200, 225, 250, 300, 350, 400, 450, 500
   };
 
+  // Windows only exposes the scales in kWindowsScalePercentages, so every derived scale has to
+  // land on one of them.
+  std::uint32_t nearest_windows_scale_percent(const double ideal_scale) {
+    const auto closest = std::ranges::min_element(
+      kWindowsScalePercentages,
+      [ideal_scale](const auto lhs, const auto rhs) {
+        return std::abs(static_cast<double>(lhs) - ideal_scale) <
+               std::abs(static_cast<double>(rhs) - ideal_scale);
+      }
+    );
+    return closest != kWindowsScalePercentages.end() ? *closest : 100u;
+  }
+
+  bool image_width_is_usable(const int image_width_mm) {
+    return image_width_mm >= VDISPLAY::kMinImageWidthMillimeters &&
+           image_width_mm <= VDISPLAY::kMaxImageWidthMillimeters;
+  }
+
   bool equals_ascii_ci(const std::string_view lhs, const std::string_view rhs) {
     return lhs.size() == rhs.size() &&
            std::ranges::equal(lhs, rhs, [](const char left, const char right) {
@@ -108,25 +126,47 @@ namespace VDISPLAY {
            starts_with_wide_ascii_ci(product_code, L"5");
   }
 
+  std::optional<virtual_display_physical_size_t> virtual_display_physical_size_mm(
+    const int configured_image_width_mm,
+    const std::uint32_t width,
+    const std::uint32_t height
+  ) {
+    if (!image_width_is_usable(configured_image_width_mm) || width == 0 || height == 0) {
+      return std::nullopt;
+    }
+
+    virtual_display_physical_size_t size {};
+    size.width_mm = static_cast<std::uint32_t>(configured_image_width_mm);
+    size.height_mm = static_cast<std::uint32_t>((std::max)(
+      1L,
+      std::lround(
+        static_cast<double>(configured_image_width_mm) *
+        static_cast<double>(height) / static_cast<double>(width)
+      )
+    ));
+    return size;
+  }
+
   std::uint32_t effective_virtual_display_scale_percent(
     const int configured_scale_percent,
     const std::uint32_t width,
-    const std::uint32_t height
+    const std::uint32_t height,
+    const int configured_image_width_mm
   ) {
     if (configured_scale_percent >= 0) {
       return static_cast<std::uint32_t>(configured_scale_percent);
     }
 
+    // A measured image width pins the client's real pixel density, so the scale follows from
+    // physics instead of from a guess keyed on resolution alone.
+    if (image_width_is_usable(configured_image_width_mm) && width > 0) {
+      const auto dots_per_inch =
+        static_cast<double>(width) * 25.4 / static_cast<double>(configured_image_width_mm);
+      return nearest_windows_scale_percent(dots_per_inch * 100.0 / VDISPLAY::kWindowsReferenceDpi);
+    }
+
     const auto short_edge = (std::min)(width, height);
-    const auto ideal_scale = static_cast<double>(short_edge) * 100.0 / 864.0;
-    const auto closest = std::ranges::min_element(
-      kWindowsScalePercentages,
-      [ideal_scale](const auto lhs, const auto rhs) {
-        return std::abs(static_cast<double>(lhs) - ideal_scale) <
-               std::abs(static_cast<double>(rhs) - ideal_scale);
-      }
-    );
-    return closest != kWindowsScalePercentages.end() ? *closest : 100u;
+    return nearest_windows_scale_percent(static_cast<double>(short_edge) * 100.0 / 864.0);
   }
 
   std::uint64_t client_uuid_to_virtual_display_id(const GUID &client_guid) {

--- a/src/platform/windows/virtual_display_sudovda.cpp
+++ b/src/platform/windows/virtual_display_sudovda.cpp
@@ -4441,7 +4441,8 @@ namespace VDISPLAY_SUDOVDA {
         const auto scale_percent = VDISPLAY::effective_virtual_display_scale_percent(
           config::video.dd.virtual_display_scale_percent,
           width,
-          height
+          height,
+          config::video.dd.virtual_display_image_width_mm
         );
         if (scale_percent > 0) {
           const bool has_virtual_target_identity =

--- a/src/platform/windows/virtual_display_sunshine.cpp
+++ b/src/platform/windows/virtual_display_sunshine.cpp
@@ -6505,8 +6505,15 @@ namespace VDISPLAY_SUNSHINE {
       }
       const auto dpi_settings_prefix = virtual_display_dpi_settings_prefix(display_id);
       const auto configured_scale = config::video.dd.virtual_display_scale_percent;
+      const auto configured_image_width_mm = config::video.dd.virtual_display_image_width_mm;
       const auto effective_scale = VDISPLAY::effective_virtual_display_scale_percent(
         configured_scale,
+        width,
+        height,
+        configured_image_width_mm
+      );
+      const auto measured_image_size = VDISPLAY::virtual_display_physical_size_mm(
+        configured_image_width_mm,
         width,
         height
       );
@@ -6519,8 +6526,22 @@ namespace VDISPLAY_SUNSHINE {
       create_request.display_id = display_id;
       create_request.width = width;
       create_request.height = height;
-      if (effective_scale > 0) {
-        const auto dpi = 96.0 * static_cast<double>(effective_scale) / 100.0;
+      if (measured_image_size) {
+        // A measured image area is reported verbatim. Windows derives DPI from the EDID, so
+        // handing it the client's real dimensions makes on-screen elements come out at their
+        // true physical size instead of a size implied by a picked scale.
+        create_request.physical_width_mm = std::clamp(
+          measured_image_size->width_mm,
+          sunshine_driver::kMinPhysicalSizeMillimeters,
+          sunshine_driver::kMaxPhysicalSizeMillimeters
+        );
+        create_request.physical_height_mm = std::clamp(
+          measured_image_size->height_mm,
+          sunshine_driver::kMinPhysicalSizeMillimeters,
+          sunshine_driver::kMaxPhysicalSizeMillimeters
+        );
+      } else if (effective_scale > 0) {
+        const auto dpi = VDISPLAY::kWindowsReferenceDpi * static_cast<double>(effective_scale) / 100.0;
         create_request.physical_width_mm = std::clamp(
           static_cast<std::uint32_t>(std::lround(static_cast<double>(width) * 25.4 / dpi)),
           sunshine_driver::kMinPhysicalSizeMillimeters,
@@ -6545,7 +6566,9 @@ namespace VDISPLAY_SUNSHINE {
                        << ", HDR peak=" << create_request.hdr_max_luminance_nits << " nits"
                        << ", scale=" << effective_scale << "%"
                        << ", physical=" << create_request.physical_width_mm << 'x'
-                       << create_request.physical_height_mm << " mm).";
+                       << create_request.physical_height_mm << " mm"
+                       << ", physical source=" << (measured_image_size ? "measured client image" : "scale")
+                       << ").";
       sunshine_driver::ControlResult<sunshine_driver::CreateTemporaryDisplayResult> create_result;
       if (reclaimed_for_reuse) {
         // Ownership is already established in-place. Enter the existing-display
@@ -7160,7 +7183,8 @@ namespace VDISPLAY_SUNSHINE {
         const auto scale_percent = VDISPLAY::effective_virtual_display_scale_percent(
           config::video.dd.virtual_display_scale_percent,
           width,
-          height
+          height,
+          config::video.dd.virtual_display_image_width_mm
         );
         if (scale_percent > 0) {
 

--- a/src_assets/common/assets/web/components/settings/SettingsOverrideEditor.vue
+++ b/src_assets/common/assets/web/components/settings/SettingsOverrideEditor.vue
@@ -581,9 +581,25 @@ async function focusOverride(key: string): Promise<void> {
                         ? t(fieldFor(key)!.placeholderKey!)
                         : undefined
                     "
+                    :list="
+                      fieldFor(key)?.presets?.length
+                        ? `${controlIdPrefix}-${key}-presets`
+                        : undefined
+                    "
                     :aria-describedby="descriptionId"
                     @input="updateFromEvent(key, $event)"
                   />
+                  <datalist
+                    v-if="fieldFor(key)?.presets?.length"
+                    :id="`${controlIdPrefix}-${key}-presets`"
+                  >
+                    <option
+                      v-for="preset in fieldFor(key)!.presets"
+                      :key="preset.value"
+                      :value="preset.value"
+                      :label="preset.label"
+                    />
+                  </datalist>
                   <AppButton
                     variant="tertiary"
                     size="compact"

--- a/src_assets/common/assets/web/components/settings/SettingsOverrideEditor.vue
+++ b/src_assets/common/assets/web/components/settings/SettingsOverrideEditor.vue
@@ -159,6 +159,7 @@ const virtualDisplayOnlyKeys = new Set([
   'virtual_display_mode',
   'virtual_display_layout',
   'dd_virtual_display_scale',
+  'dd_virtual_display_image_width_mm',
   'dd_activate_virtual_display',
   'dd_virtual_display_permanent_count',
   'dd_paused_virtual_display_timeout_secs',

--- a/src_assets/common/assets/web/configs/clientImageWidthPresets.ts
+++ b/src_assets/common/assets/web/configs/clientImageWidthPresets.ts
@@ -1,0 +1,30 @@
+/**
+ * Measured image-area widths offered as suggestions for `dd_virtual_display_image_width_mm`.
+ *
+ * That setting takes the width, in millimetres, of the image area a client actually displays.
+ * Working it out means reading a datasheet, so the devices someone has already worked out are
+ * kept here rather than measured twice. This is an ordinary list with no behaviour attached:
+ * add a row to offer another device, delete one to stop offering it. Nothing else keys off the
+ * labels, and any width can still be typed by hand, so a device missing from the list is a
+ * convenience gap and never a blocker.
+ *
+ * `widthMm` is the full width of the panel's active area, rounded to whole millimetres because
+ * that is the granularity an EDID carries. A stream wider in aspect than the panel is
+ * letterboxed and still fills that width; a stream narrower than the panel is pillarboxed and
+ * needs a smaller number than the one listed here.
+ */
+export interface ClientImageWidthPreset {
+  /** Device the measurement belongs to. A product name, so it is not translated. */
+  label: string;
+  /** Pixel mode the measurement was taken at, shown for context. */
+  mode: string;
+  /** Width of the panel's active image area, in whole millimetres. */
+  widthMm: number;
+}
+
+export const clientImageWidthPresets: ClientImageWidthPreset[] = [
+  // Dell's manual gives a 344.68 x 215.42 mm active area at 2560x1600, so 188.65 PPI.
+  { label: 'Alienware m16 R2', mode: '2560x1600', widthMm: 345 },
+  // Samsung's 8.0-inch inner panel at 2504x2256 works out to 150.97 x 136.01 mm, so 421.3 PPI.
+  { label: 'Galaxy Z Fold8 Ultra (inner panel)', mode: '2504x2256', widthMm: 151 },
+];

--- a/src_assets/common/assets/web/configs/settingsSchema.ts
+++ b/src_assets/common/assets/web/configs/settingsSchema.ts
@@ -87,6 +87,7 @@ export const clientOverrideableKeys = new Set([
   'dd_use_sunshine_virtual_display_driver',
   'dd_activate_virtual_display',
   'dd_virtual_display_scale',
+  'dd_virtual_display_image_width_mm',
   'dd_virtual_display_permanent_count',
   'dd_mode_remapping',
   'dd_wa_dummy_plug_hdr10',
@@ -351,6 +352,14 @@ const virtualDisplayCustomizationFields = (): SettingsField[] => [
   select('dd_virtual_display_scale', virtualScaleOptions, {
     labelKey: 'ui.settings.fields.dd_virtual_display_scale.label',
     descriptionKey: 'ui.settings.fields.dd_virtual_display_scale.description',
+    visibleWhen: { key: 'virtual_display_mode', notEquals: 'disabled' },
+  }),
+  number('dd_virtual_display_image_width_mm', {
+    labelKey: 'ui.settings.fields.dd_virtual_display_image_width_mm.label',
+    descriptionKey: 'ui.settings.fields.dd_virtual_display_image_width_mm.description',
+    min: 0,
+    max: 2000,
+    step: 1,
     visibleWhen: { key: 'virtual_display_mode', notEquals: 'disabled' },
   }),
 ];
@@ -807,6 +816,7 @@ export const settingsDefaults: Record<string, unknown> = {
   virtual_display_mode: 'per_client',
   virtual_display_layout: 'exclusive',
   dd_virtual_display_scale: -1,
+  dd_virtual_display_image_width_mm: 0,
   frame_limiter_enable: false,
   frame_limiter_provider: 'auto',
   frame_limiter_fps_limit: 0,

--- a/src_assets/common/assets/web/configs/settingsSchema.ts
+++ b/src_assets/common/assets/web/configs/settingsSchema.ts
@@ -1,3 +1,5 @@
+import { clientImageWidthPresets } from './clientImageWidthPresets.ts';
+
 export type SettingsFieldKind =
   | 'boolean'
   | 'number'
@@ -15,6 +17,16 @@ export interface SettingsOption {
   value: string;
 }
 
+/**
+ * A suggested value for a field, offered alongside free entry rather than replacing it.
+ * Unlike SettingsOption the label is literal text: these name real-world things such as
+ * device models, which are not translated.
+ */
+export interface SettingsPreset {
+  label: string;
+  value: string;
+}
+
 export interface SettingsVisibility {
   key: string;
   equals?: string | boolean;
@@ -28,6 +40,7 @@ export interface SettingsField {
   descriptionKey?: string;
   warningKey?: string;
   options?: SettingsOption[];
+  presets?: SettingsPreset[];
   min?: number;
   max?: number;
   step?: number;
@@ -360,6 +373,10 @@ const virtualDisplayCustomizationFields = (): SettingsField[] => [
     min: 0,
     max: 2000,
     step: 1,
+    presets: clientImageWidthPresets.map((preset) => ({
+      label: `${preset.label} - ${preset.mode}`,
+      value: String(preset.widthMm),
+    })),
     visibleWhen: { key: 'virtual_display_mode', notEquals: 'disabled' },
   }),
 ];

--- a/src_assets/common/assets/web/public/assets/locale/ui/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/ui/en.json
@@ -1360,6 +1360,10 @@
           "description": "Keep up to four virtual monitors outside streams. 0 creates them only when needed.",
           "label": "Always-available virtual displays"
         },
+        "dd_virtual_display_image_width_mm": {
+          "description": "Width of the image area your client actually displays, in millimetres. Windows reads it from the virtual display's EDID and derives DPI from it, so buttons and the cursor match the physical size they have on the host monitor. Measure the image area, not the device: a letterboxed stream is smaller than the panel. 0 disables it. Examples: 345 for an Alienware m16 R2 at 2560x1600, 151 for a Galaxy Z Fold8 Ultra inner panel at 2504x2256.",
+          "label": "Client image width (mm)"
+        },
         "dd_virtual_display_scale": {
           "description": "Adjust interface size without changing the resolution requested by the client.",
           "label": "Windows scaling"

--- a/src_assets/common/assets/web/public/assets/locale/ui/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/ui/en.json
@@ -1361,7 +1361,7 @@
           "label": "Always-available virtual displays"
         },
         "dd_virtual_display_image_width_mm": {
-          "description": "Width of the image area your client actually displays, in millimetres. Windows reads it from the virtual display's EDID and derives DPI from it, so buttons and the cursor match the physical size they have on the host monitor. Measure the image area, not the device: a letterboxed stream is smaller than the panel. 0 disables it. Examples: 345 for an Alienware m16 R2 at 2560x1600, 151 for a Galaxy Z Fold8 Ultra inner panel at 2504x2256.",
+          "description": "Width of the image area your client actually displays, in millimetres. Windows reads it from the virtual display's EDID and derives DPI from it, so buttons and the cursor match the physical size they have on the host monitor. Measure the image area, not the device: a letterboxed stream is smaller than the panel. The field suggests measured widths for devices that have already been worked out, such as the Alienware m16 R2 and the inner panel of a Galaxy Z Fold8 Ultra; any other width can be typed in. 0 disables it.",
           "label": "Client image width (mm)"
         },
         "dd_virtual_display_scale": {

--- a/src_assets/common/assets/web/scripts/v2-parity.test.ts
+++ b/src_assets/common/assets/web/scripts/v2-parity.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { clientImageWidthPresets } from '../configs/clientImageWidthPresets.ts';
+import { settingsCategories } from '../configs/settingsSchema.ts';
 import {
   displayFieldVisibility,
   downsampleHostHistory,
@@ -72,4 +74,46 @@ test('host compute readouts label current and peak values explicitly', () => {
     /ENC[\s\S]*t\('stats\.current'\)[\s\S]*current\.encoder[\s\S]*t\('stats\.peak'\)[\s\S]*peak\.encoder/,
   );
   assert.doesNotMatch(chart, /t\('stats\.peak'\)[^\n]*\/[^\n]*t\('stats\.current'\)/);
+});
+
+test('client image-width suggestions reach the field and stay inside what the host accepts', () => {
+  const field = settingsCategories
+    .flatMap((category) => category.groups)
+    .flatMap((group) => group.fields)
+    .find((candidate) => candidate.key === 'dd_virtual_display_image_width_mm');
+  assert.ok(field, 'the client image width setting must exist to hang suggestions off');
+
+  assert.deepEqual(
+    field.presets,
+    clientImageWidthPresets.map((preset) => ({
+      label: `${preset.label} - ${preset.mode}`,
+      value: String(preset.widthMm),
+    })),
+    'every row of the preset table has to reach the field, in table order',
+  );
+
+  // config::apply_config() drops a width outside 10-2000 mm with a warning, so a suggestion
+  // outside that band would be offered and then silently ignored by the host.
+  for (const preset of clientImageWidthPresets) {
+    assert.ok(
+      Number.isInteger(preset.widthMm) && preset.widthMm >= 10 && preset.widthMm <= 2000,
+      `${preset.label} must be a whole number of millimetres the host will accept`,
+    );
+    assert.ok(preset.label && preset.mode, `${preset.label} must name a device and a mode`);
+  }
+
+  const values = clientImageWidthPresets.map((preset) => preset.widthMm);
+  assert.equal(new Set(values).size, values.length, 'two devices must not share one width');
+  const labels = clientImageWidthPresets.map((preset) => `${preset.label} - ${preset.mode}`);
+  assert.equal(new Set(labels).size, labels.length, 'suggestion labels must be distinguishable');
+});
+
+test('the worked examples keep the widths the docs and the C++ tests are written against', () => {
+  // tests/unit/platform/windows/test_virtual_display_sunshine.cpp asserts these two widths
+  // resolve to 200% and 450%; docs/configuration.md quotes the same measurements. Changing a
+  // width here without changing those leaves three descriptions of one number disagreeing.
+  const widthFor = (label: string): number | undefined =>
+    clientImageWidthPresets.find((preset) => preset.label === label)?.widthMm;
+  assert.equal(widthFor('Alienware m16 R2'), 345);
+  assert.equal(widthFor('Galaxy Z Fold8 Ultra (inner panel)'), 151);
 });

--- a/src_assets/common/assets/web/views/ApplicationView.vue
+++ b/src_assets/common/assets/web/views/ApplicationView.vue
@@ -3245,9 +3245,25 @@ onBeforeUnmount(() => {
                           :step="overrideField(key)?.step"
                           :value="String(overrideValue(key) ?? '')"
                           :placeholder="overridePlaceholder(key)"
+                          :list="
+                            overrideField(key)?.presets?.length
+                              ? `app-override-${key}-presets`
+                              : undefined
+                          "
                           :aria-describedby="descriptionId"
                           @input="updateOverrideFromEvent(key, overrideField(key), $event)"
                         />
+                        <datalist
+                          v-if="overrideField(key)?.presets?.length"
+                          :id="`app-override-${key}-presets`"
+                        >
+                          <option
+                            v-for="preset in overrideField(key)!.presets"
+                            :key="preset.value"
+                            :value="preset.value"
+                            :label="preset.label"
+                          />
+                        </datalist>
                         <AppButton
                           variant="tertiary"
                           size="compact"

--- a/src_assets/common/assets/web/views/ApplicationView.vue
+++ b/src_assets/common/assets/web/views/ApplicationView.vue
@@ -527,6 +527,7 @@ const virtualDisplayOnlyOverrideKeys = new Set([
   'virtual_display_mode',
   'virtual_display_layout',
   'dd_virtual_display_scale',
+  'dd_virtual_display_image_width_mm',
   'dd_activate_virtual_display',
   'dd_virtual_display_permanent_count',
   'dd_paused_virtual_display_timeout_secs',

--- a/src_assets/common/assets/web/views/SettingsView.vue
+++ b/src_assets/common/assets/web/views/SettingsView.vue
@@ -929,8 +929,17 @@ onMounted(() => void load());
                     :step="field.step"
                     :value="String(values[field.key] ?? '')"
                     :placeholder="field.placeholderKey ? t(field.placeholderKey) : undefined"
+                    :list="field.presets?.length ? `setting-${field.key}-presets` : undefined"
                     @input="updateValue(field.key, $event, field)"
                   />
+                  <datalist v-if="field.presets?.length" :id="`setting-${field.key}-presets`">
+                    <option
+                      v-for="preset in field.presets"
+                      :key="preset.value"
+                      :value="preset.value"
+                      :label="preset.label"
+                    />
+                  </datalist>
                 </div>
               </div>
               <div

--- a/tests/unit/platform/windows/test_virtual_display_sunshine.cpp
+++ b/tests/unit/platform/windows/test_virtual_display_sunshine.cpp
@@ -46,6 +46,77 @@ TEST(SunshineVirtualDisplay, ConfiguredScalePreservesAutomaticAndExactValues) {
   EXPECT_EQ(VDISPLAY::effective_virtual_display_scale_percent(200, 1920, 1080), 200u);
 }
 
+TEST(SunshineVirtualDisplay, MeasuredClientImageWidthDrivesTheRecommendedScale) {
+  // Alienware m16 R2: 344.68 x 215.42 mm of active area at 2560x1600, so 188.65 PPI.
+  EXPECT_EQ(VDISPLAY::effective_virtual_display_scale_percent(-1, 2560, 1600, 345), 200u);
+  // Galaxy Z Fold8 Ultra inner panel, landscape: 150.97 x 136.01 mm at 2504x2256, so 421.3 PPI.
+  EXPECT_EQ(VDISPLAY::effective_virtual_display_scale_percent(-1, 2504, 2256, 151), 450u);
+}
+
+TEST(SunshineVirtualDisplay, ResolutionHeuristicRunsOnlyWithoutAMeasuredImageWidth) {
+  // The same two modes without a measurement. A pixel count cannot separate a phone panel from
+  // a laptop panel, so the heuristic lands far from the density either client really has.
+  EXPECT_EQ(VDISPLAY::effective_virtual_display_scale_percent(-1, 2560, 1600, 0), 175u);
+  EXPECT_EQ(VDISPLAY::effective_virtual_display_scale_percent(-1, 2504, 2256, 0), 250u);
+}
+
+TEST(SunshineVirtualDisplay, OutOfRangeImageWidthFallsBackToTheResolutionHeuristic) {
+  EXPECT_EQ(VDISPLAY::effective_virtual_display_scale_percent(-1, 2560, 1600, 5), 175u);
+  EXPECT_EQ(VDISPLAY::effective_virtual_display_scale_percent(-1, 2560, 1600, 5000), 175u);
+}
+
+TEST(SunshineVirtualDisplay, ExplicitScaleOutranksAMeasuredImageWidth) {
+  EXPECT_EQ(VDISPLAY::effective_virtual_display_scale_percent(150, 2560, 1600, 345), 150u);
+  EXPECT_EQ(VDISPLAY::effective_virtual_display_scale_percent(0, 2560, 1600, 345), 0u);
+}
+
+TEST(SunshineVirtualDisplay, PhysicalSizeFollowsTheModePixelAspect) {
+  const auto laptop = VDISPLAY::virtual_display_physical_size_mm(345, 2560, 1600);
+  ASSERT_TRUE(laptop.has_value());
+  EXPECT_EQ(laptop->width_mm, 345u);
+  EXPECT_EQ(laptop->height_mm, 216u);  // 215.42 mm on the datasheet.
+
+  const auto foldable = VDISPLAY::virtual_display_physical_size_mm(151, 2504, 2256);
+  ASSERT_TRUE(foldable.has_value());
+  EXPECT_EQ(foldable->width_mm, 151u);
+  EXPECT_EQ(foldable->height_mm, 136u);  // 136.01 mm on the datasheet.
+}
+
+TEST(SunshineVirtualDisplay, PhysicalSizeIsAbsentWithoutAUsableImageWidth) {
+  EXPECT_FALSE(VDISPLAY::virtual_display_physical_size_mm(0, 2560, 1600).has_value());
+  EXPECT_FALSE(VDISPLAY::virtual_display_physical_size_mm(-345, 2560, 1600).has_value());
+  EXPECT_FALSE(VDISPLAY::virtual_display_physical_size_mm(5000, 2560, 1600).has_value());
+  EXPECT_FALSE(VDISPLAY::virtual_display_physical_size_mm(345, 0, 1600).has_value());
+  EXPECT_FALSE(VDISPLAY::virtual_display_physical_size_mm(345, 2560, 0).has_value());
+}
+
+TEST(SunshineVirtualDisplay, MeasuredImageWidthResolvesIdempotently) {
+  // Every reconnect re-runs this against a display that already carries the previous answer.
+  // Both halves have to be pure functions of the configuration; if either read back what it
+  // wrote last time, reconnecting would walk the EDID and the Windows scale a step further
+  // from the measurement each time.
+  const auto first_size = VDISPLAY::virtual_display_physical_size_mm(151, 2504, 2256);
+  const auto second_size = VDISPLAY::virtual_display_physical_size_mm(151, 2504, 2256);
+  ASSERT_TRUE(first_size.has_value());
+  ASSERT_TRUE(second_size.has_value());
+  EXPECT_EQ(first_size->width_mm, second_size->width_mm);
+  EXPECT_EQ(first_size->height_mm, second_size->height_mm);
+
+  const auto first_scale = VDISPLAY::effective_virtual_display_scale_percent(-1, 2504, 2256, 151);
+  EXPECT_EQ(VDISPLAY::effective_virtual_display_scale_percent(-1, 2504, 2256, 151), first_scale);
+
+  // Feeding the derived scale back in as an explicit setting has to settle on the same value
+  // and leave the advertised size alone, rather than compounding on itself.
+  EXPECT_EQ(
+    VDISPLAY::effective_virtual_display_scale_percent(static_cast<int>(first_scale), 2504, 2256, 151),
+    first_scale
+  );
+  const auto size_after = VDISPLAY::virtual_display_physical_size_mm(151, 2504, 2256);
+  ASSERT_TRUE(size_after.has_value());
+  EXPECT_EQ(size_after->width_mm, first_size->width_mm);
+  EXPECT_EQ(size_after->height_mm, first_size->height_mm);
+}
+
 TEST(SunshineVirtualDisplay, PerClientDisplayIdsDifferByClientUuid) {
   EXPECT_NE(
     VDISPLAY::client_uuid_to_virtual_display_id(kClientGuid),


### PR DESCRIPTION
> Same change as Nonary/Vibepollo#452, opened here too because Vibeshine is where features
> originate. Take whichever side suits you and I will close the other — they are not meant to
> both land.

## The problem

The stream protocol carries pixels, never physical dimensions. I checked nvhttp `/launch`, the SDP
attributes in `src/rtsp.cpp`, and moonlight-common-c: nothing anywhere carries a client's screen size
or DPI. So the host genuinely cannot tell a 2504-pixel-wide phone panel from a 2504-pixel-wide desktop
monitor.

`effective_virtual_display_scale_percent()` deals with that by guessing from the short edge alone
(`src/platform/windows/virtual_display_identity.cpp`):

```cpp
const auto ideal_scale = static_cast<double>(short_edge) * 100.0 / 864.0;
```

Resolution is a poor proxy for density, and the existing tests already show the seam: 3440x1440 and
1440x2560 are very different displays and both resolve to 175%.

The user-visible result is that buttons, text, and the cursor come out a different physical size on the
client than they are on the host's own monitor. Nonary/Vibepollo#386 is this, from the other end: a user picked 175% in
Vibepollo, Windows recommended 150% "on two different phones", and the two disagreed until they set
Windows by hand.

## The approach

Rather than add another picked percentage, this takes the physical route the Apollo maintainer already
argued for in ClassicOldSong/Apollo#290 (the issue ClassicOldSong/Apollo#1013 was closed as a duplicate
of). Asked about specifying scaling as a percentage from the client, he answered:

> Nope, that could mess up with Windows native DPI settings.

and then:

> Physical size is baked into EDID and Windows can determine DPI based on the information. It's more
> precise than manually picked scales.

He also noted that auto-detecting the client's physical size is not feasible and it has to be entered
manually — which matches what the protocol survey above found.

The host already synthesises an EDID physical size in `virtual_display_sunshine.cpp`, but it derives the
millimetres *from* the scale (`dpi = 96 * scale / 100`, then `mm = px * 25.4 / dpi`). This change lets
that run in the honest direction: measure the client once, put the real millimetres in the EDID, and let
Windows derive DPI from them the way it does for any real monitor. The Windows scale becomes a derived
value rather than the primary input.

## The setting

One new option, `dd_virtual_display_image_width_mm`: the width, in millimetres, of the image area the
client actually displays. `0` disables it and nothing changes.

It is deliberately the **image area**, not the device. On a letterboxed panel those differ — a 16:10
stream on the 8.0-inch inner panel of a Galaxy Z Fold8 Ultra occupies about 7.01 inches of it — so a
device diagonal would bake in an error. Height is derived from the width and the requested mode's pixel
aspect, so only one number is configured.

## The calculation

```
dpi           = width_px * 25.4 / image_width_mm
ideal_scale % = dpi / 96 * 100          -> snapped to the scales Windows exposes
height_mm     = image_width_mm * height_px / width_px
```

Worked through on two measured clients:

| Client | Mode | Image area (mm) | Configured | DPI | Ideal | Snapped | Heuristic gives |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Alienware m16 R2 | 2560x1600 | 344.68 x 215.42 | `345` | 188.5 | 196.3% | **200%** | 175% |
| Galaxy Z Fold8 Ultra (inner, landscape) | 2504x2256 | 150.97 x 136.01 | `151` | 421.2 | 438.8% | **450%** | 250% |

Both sets of dimensions are from the vendors: the m16 R2 active area is Dell's own manual (188.65 PPI,
which the numbers reproduce exactly), and the Z Fold8 Ultra figures follow from Samsung's 8.0-inch inner
panel spec (421.3 PPI, likewise reproduced). The phone is the case that shows why this matters — the
resolution heuristic is off by 200 percentage points there.

## Suggested widths

Nobody knows their client's image width offhand, and a number that needs a datasheet to find is a number
nobody sets. So the two measurements above are also offered in the UI.
`src_assets/common/assets/web/configs/clientImageWidthPresets.ts` is a plain table of device, mode, and
width:

```ts
export const clientImageWidthPresets: ClientImageWidthPreset[] = [
  // Dell's manual gives a 344.68 x 215.42 mm active area at 2560x1600, so 188.65 PPI.
  { label: 'Alienware m16 R2', mode: '2560x1600', widthMm: 345 },
  // Samsung's 8.0-inch inner panel at 2504x2256 works out to 150.97 x 136.01 mm, so 421.3 PPI.
  { label: 'Galaxy Z Fold8 Ultra (inner panel)', mode: '2504x2256', widthMm: 151 },
];
```

The settings schema hangs that table off the field as a generic `presets` property, and the three
editors that render numeric fields - global settings, per-client overrides, per-app overrides - render
any field's suggestions through a native `<datalist>`. Nothing is keyed on this particular setting, and
no device name reaches the C++ at all: the host still only ever sees a number of millimetres.

The table binds nothing. It is a list of worked examples rather than a supported-device list, the field
still accepts any width the host accepts, and a device missing from it is a convenience gap rather than
a blocker. Adding one is a single row.

## Idempotency

Reconnecting re-runs this against a display that already carries the previous answer, so both halves are
pure functions of the configuration and read nothing back:

- The EDID size is computed from the configured millimetres and the mode. It cannot drift, because
  nothing feeds the previous size back in.
- The Windows scale path was already safe and stays that way. `set_display_scale_percent()` re-queries
  `recommended_index` and recomputes `desired_relative` from scratch on every call, and short-circuits
  when `current_index == desired_index`. The relative index never accumulates.

`MeasuredImageWidthResolvesIdempotently` covers both, including feeding a derived scale back in as an
explicit setting.

## Precedence

Unchanged for anyone not setting the new option, and the existing semantics still win:

- an explicit `dd_virtual_display_scale` percentage overrides the measurement;
- `0` ("preserve Windows' choice") still leaves the Windows DPI setting alone;
- only the automatic (`-1`) recommendation is refined.

The measured EDID size is applied regardless of the scale mode, since reporting a true physical size is
correct even when Vibeshine is not touching the DPI setting.

## Scope

Kept small on purpose. No protocol extension, no client auto-detection, no new UI component — the
setting is a plain number field with a native list of suggested widths, and it reuses
`effective_virtual_display_scale_percent()` and the
existing `config_overrides` allowlists rather than adding a parallel path, so it is already
per-client and per-app overridable. The scale-snapping helper is extracted once and shared by both the
heuristic and the derived path.

`web-legacy` is not wired up; it is excluded from packaging in `cmake/packaging/common.cmake`.

## Testing — please read

Seven test cases were added to `tests/unit/platform/windows/test_virtual_display_sunshine.cpp`, in the
existing style, covering the derived scale, the fallback when unset or out of range, explicit-scale
precedence, the derived physical size, the absent cases, and idempotency. Two more were added to
`src_assets/common/assets/web/scripts/v2-parity.test.ts`, pinning the suggestion table to the field and
to the widths the C++ tests and the documentation are written against, so the three cannot drift apart
silently.

**I could not run the project's own test suite, and I have not tested this on a real host.** Vibeshine
builds under MSYS2 UCRT64 and that toolchain is not installed on my machine; the full build also needs
the virtual display driver SDK (`<virtual_display/driver/control_client.h>`). What I did instead, run against this tree rather than carried over from the Vibepollo branch:

- Compiled the struct, the constants, the scale table and both function bodies, all extracted verbatim
  from this repository's `virtual_display.h` and `virtual_display_identity.cpp`, with MSVC at
  `/W4 /permissive- /std:c++20`, and ran every assertion from the nine scale and size test cases, the
  two pre-existing ones included as regression checks. 35/35 pass, no warnings.
- Ran the web test suite (`npm run test:v2-parity`, 6/6), the TypeScript typecheck
  (`vue-tsc --noEmit`, clean) and the production build (`npm run build`, clean) against this tree.
  `prettier --check` reports nothing on any line this PR adds; it does flag two pre-existing
  violations elsewhere in `ApplicationView.vue` and `SettingsOverrideEditor.vue`, on encoder-option
  lines this PR does not touch, which I have left alone.

**Not verified:** that the whole project compiles under the real toolchain, and — most importantly —
that a real client actually ends up with correctly-sized UI. The EDID path in particular needs someone
with the driver and a device to confirm that Windows picks up the advertised size and settles on the
expected scale. I would not merge this without that check.

## AI assistance

This change was written with AI assistance (Claude). Per CONTRIBUTING.md I have reviewed the diff and I
understand what it does; the arithmetic above was verified independently against the vendor figures, and
the limits of what was actually executed are stated plainly in the section above rather than implied.

## Design discussion

The shape of this — EDID physical size as the input rather than a picked percentage — is open for
discussion in Nonary/Vibepollo#453, including the alternatives I considered and the questions I'd most
like answered before this goes any further. If you'd rather implement it yourself, everything needed is
written up there and this draft can simply be closed.

Refs ClassicOldSong/Apollo#290, ClassicOldSong/Apollo#1013, Nonary/Vibepollo#386,
Nonary/Vibepollo#452, Nonary/Vibepollo#453.

