### PR TITLE
Fix zero-timeout queue polling stall on Windows

### DIFF
--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -326,7 +326,12 @@ namespace safe {
       }
 
       while (_queue.empty()) {
-        if (!_continue || _cv.wait_for(ul, delay) == std::cv_status::timeout) {
+        // A zero-duration pop is used as a poll in hot paths. Calling
+        // condition_variable::wait_for(0) can still yield until the next
+        // Windows scheduler tick, turning a nominally nonblocking operation
+        // into a recurring ~15.6ms stall.
+        if (!_continue || delay <= decltype(delay)::zero() ||
+            _cv.wait_for(ul, delay) == std::cv_status::timeout) {
           return util::false_v<status_t>;
         }
       }


### PR DESCRIPTION
## Summary

Make `safe::queue_t::pop(0ms)` genuinely nonblocking by returning immediately when the queue is empty and the requested timeout is zero (or negative), instead of calling `std::condition_variable::wait_for()`.

Fixes #277.

## Root cause

The asynchronous Windows capture worker polls its context queue once per captured frame:

```cpp
while (auto pending_context = capture_ctx_queue->pop(0ms)) {
  // ...
}
```

`queue_t::pop()` previously called `_cv.wait_for(lock, delay)` even when `delay == 0ms`. Although the API caller requested a poll, a zero-duration condition-variable wait is not guaranteed to behave like a userspace state check. On the affected Windows 25H2 system it yielded the critical capture thread until the next scheduler interval, adding approximately 15.5 ms to every capture-delivery callback.

At a requested 120 FPS, the WGC pacing interval is 8.33 ms. The unintended wait therefore made every next pacing deadline expire before the capture loop could reach it. WGC itself continued producing approximately 120 FPS, but the consumer delivered only about 64 FPS and host processing latency increased to roughly 19.5 ms.

This was unrelated to NVENC split-frame encoding. Split-frame encoding was disabled in the validated sessions, and NVENC submission took only about 3.8 ms.

## Fix

When the queue is empty, return immediately if `delay <= 0` before entering the condition variable. Positive-duration waits retain their existing behavior, and an already-queued value is still consumed before this check.

## Validation

The affected system was tested at 3024x1890, HEVC, 120 FPS, RTX 4090, Windows 25H2. Diagnostic builds before and after this exact change produced the following steady-state results:

| Metric | Before | After |
| --- | ---: | ---: |
| Encoded frames per 10 seconds | 640-641 | 1184-1191 |
| Effective encoded frame rate | ~64 FPS | ~118-119 FPS |
| WGC capture-delivery callback | ~15.47 ms | ~0.00-0.01 ms |
| WGC capture-loop iteration | ~15.62 ms | ~8.42 ms |
| Host frame-processing latency | ~19.50 ms | ~3.75-4.11 ms |
| Expired pacing deadlines (`woke_late`) | ~640 per 10 s | 0 |
| Dropped encoder submissions | 0 | 0 |

During the final steady-motion interval, the WGC helper published about 117-127 FPS and the encoder consumed about 118-119 FPS. Remaining snapshot misses correlated with periods where the captured application itself produced fewer frames; they no longer caused expired pacing deadlines or a 64 FPS ceiling.

The pre-existing queue unit tests cover both empty and populated `pop(0ms)` behavior. I also compiled and ran a focused local syntax/behavior check for both cases. A signed Windows installer containing this change was built successfully by GitHub Actions and validated on the affected machine.

## Scope

This PR intentionally contains only the confirmed generic queue fix. The temporary WGC/NVENC instrumentation and earlier experimental pacing changes used during diagnosis are not included.
